### PR TITLE
Changes download link to release page from github

### DIFF
--- a/install/inc.download.md
+++ b/install/inc.download.md
@@ -1,6 +1,6 @@
 #### Download Airsonic WAR package
 
-Download the latest Airsonic .war package from the [download page](/download), or with the command below:
+Download the latest Airsonic .war package from the [download page](https://github.com/airsonic/airsonic/releases/), or with the command below:
 
 ```
 wget {{ site.repo }}/download/v{{ site.stable_version }}/airsonic.war


### PR DESCRIPTION
This change links to an existing page for war downloads instead of a 404 (the /download page doesn't exist)