### PR TITLE
Add install instructions for Tomcat under FreeBSD and Debian 9+

### DIFF
--- a/install/example/freebsd_freenas.md
+++ b/install/example/freebsd_freenas.md
@@ -75,6 +75,7 @@ Start tomcat8:
 
 ```
 echo tomcat8_enable="YES" >> /etc/rc.conf
+echo tomcat8_env="LANG=en_US.UTF-8 TZ=Europe/Paris" >> /etc/rc.conf
 service tomcat8 start
 ```
 

--- a/install/war_tomcat.md
+++ b/install/war_tomcat.md
@@ -126,6 +126,8 @@ supporting Unicode characters, by adding the following line to `/etc/rc.conf`
 tomcat8_env="LANG=en_US.UTF-8 TZ=Europe/Paris"
 ```
 
+For more information, follow the complete [installation guide for FreeBSD](docs/install/example/freebsd_freenas/).
+
 ##### On Red Hat / Fedora
 
 **Work in progress**

--- a/install/war_tomcat.md
+++ b/install/war_tomcat.md
@@ -56,6 +56,66 @@ INFO: Deployment of web application archive /var/lib/tomcat8/webapps/airsonic.wa
 
 Airsonic should be running at [http://localhost:8080/airsonic](http://localhost:8080/airsonic) if installed locally, replace `localhost` with your server IP address if installed remotely.
 
+##### On Debian 9 / Ubuntu > 18.04
+
+Debian 9 and Ubuntu 18.04 propose the `tomcat9` package.
+
+Create the Airsonic directory and assign ownership to the Tomcat system user (if running tomcat as a service):
+
+```
+sudo mkdir /var/airsonic/
+sudo chown -R tomcat9:tomcat9 /var/airsonic/
+```
+
+Stop the `tomcat9` service:
+
+```
+sudo systemctl stop tomcat9.service
+```
+
+Remove the possible existing airsonic files from the `$TOMCAT_HOME`:
+
+```
+sudo rm /var/lib/tomcat9/webapps/airsonic.war
+sudo rm -R /var/lib/tomcat9/webapps/airsonic/
+sudo rm -R /var/lib/tomcat9/work/*
+```
+
+Move the downloaded WAR file in the `$TOMCAT_HOME/webapps` folder and assign ownership to the Tomcat system user:
+
+```
+sudo mv airsonic.war /var/lib/tomcat9/webapps/airsonic.war
+sudo chown tomcat9:tomcat9 /var/lib/tomcat9/webapps/airsonic.war
+```
+
+Make sure that the Tomcat service has access to your music folders, by adding
+the following lines to `/etc/systemd/system/tomcat9.service.d/airsonic.conf`
+(add as many `ReadWritePaths` lines as necessary):
+
+```
+[Service]
+ReadWritePaths=/var/airsonic/
+```
+
+Reload the systemd configuration:
+
+```
+sudo systemctl daemon-reload
+```
+
+Restart the `tomcat9` service:
+
+```
+sudo systemctl start tomcat9.service
+```
+
+> **NOTE**: it may take ~30 seconds after the service restarts for Tomcat to fully deploy the app. You can monitor /var/log/tomcat9/catalina.out for the following message:
+```
+INFO: Deployment of web application archive /var/lib/tomcat9/webapps/airsonic.war has finished in 46,192 ms
+```
+
+Airsonic should be running at [http://localhost:8080/airsonic](http://localhost:8080/airsonic) if installed locally, replace `localhost` with your server IP address if installed remotely.
+
 ##### On Red Hat / Fedora
 
 **Work in progress**

--- a/install/war_tomcat.md
+++ b/install/war_tomcat.md
@@ -22,13 +22,13 @@ sudo mkdir /var/airsonic/
 sudo chown -R tomcat8:tomcat8 /var/airsonic/
 ```
 
-Stop the tomcat8 service:
+Stop the `tomcat8` service:
 
 ```
 sudo systemctl stop tomcat8.service
 ```
 
-Remove the possible existing airsonic files from the TOMCAT_HOME:
+Remove the possible existing airsonic files from the `$TOMCAT_HOME`:
 
 ```
 sudo rm /var/lib/tomcat8/webapps/airsonic.war
@@ -36,14 +36,14 @@ sudo rm -R /var/lib/tomcat8/webapps/airsonic/
 sudo rm -R /var/lib/tomcat8/work/*
 ```
 
-Move the downloaded WAR file in the TOMCAT_HOME/webapps/ folder and assign ownership to the Tomcat system user:
+Move the downloaded WAR file in the `$TOMCAT_HOME/webapps` folder and assign ownership to the Tomcat system user:
 
 ```
 sudo mv airsonic.war /var/lib/tomcat8/webapps/airsonic.war
 sudo chown tomcat8:tomcat8 /var/lib/tomcat8/webapps/airsonic.war
 ```
 
-Restart the tomcat8 service:
+Restart the `tomcat8` service:
 
 ```
 sudo systemctl start tomcat8.service
@@ -54,7 +54,7 @@ sudo systemctl start tomcat8.service
 INFO: Deployment of web application archive /var/lib/tomcat8/webapps/airsonic.war has finished in 46,192 ms
 ```
 
-Airsonic should be running at [http://localhost:8080/airsonic](http://localhost:8080/airsonic) if installed locally, replace `localhost` with your server IP address if installed remotly.
+Airsonic should be running at [http://localhost:8080/airsonic](http://localhost:8080/airsonic) if installed locally, replace `localhost` with your server IP address if installed remotely.
 
 ##### On Red Hat / Fedora
 

--- a/install/war_tomcat.md
+++ b/install/war_tomcat.md
@@ -116,6 +116,16 @@ INFO: Deployment of web application archive /var/lib/tomcat9/webapps/airsonic.wa
 
 Airsonic should be running at [http://localhost:8080/airsonic](http://localhost:8080/airsonic) if installed locally, replace `localhost` with your server IP address if installed remotely.
 
+##### On FreeBSD
+
+After installing Tomcat, make sure that the Tomcat service is configured for
+supporting Unicode characters, by adding the following line to `/etc/rc.conf`
+(for the `tomcat8` package, replace `en_US` and `Europe/Paris` if necessary):
+
+```
+tomcat8_env="LANG=en_US.UTF-8 TZ=Europe/Paris"
+```
+
 ##### On Red Hat / Fedora
 
 **Work in progress**


### PR DESCRIPTION
This adds some notes to the installation process under FreeBSD (for the `tomcat8` package) and Debian 9+ (for the `tomcat9` package).

Relevant issues:
* Debian 9: https://github.com/airsonic/airsonic/issues/1055
* FreeBSD: https://github.com/airsonic/airsonic/issues/780