### PR TITLE
Fixed incorrect title on Update page

### DIFF
--- a/update.md
+++ b/update.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: Airsonic Applications
+title: Update
 permalink: /docs/update/
 ---
 


### PR DESCRIPTION
I updated the `/docs/update` page to have `Update` as the title instead of `Airsonic Applications`.