### PR TITLE
Corrected systemctl syntax

### DIFF
--- a/update.md
+++ b/update.md
@@ -8,7 +8,7 @@ permalink: /docs/update/
 
 #### Standalone deployment
 
-If you're using systemd, a simple `systemctl airsonic restart` should be
+If you're using systemd, a simple `systemctl restart airsonic` should be
 enough.
 
 #### Tomcat deployment


### PR DESCRIPTION
Update documentation has the wrong syntax for systemctl. Operation comes before service.